### PR TITLE
clear history on closing query history form

### DIFF
--- a/src/components/sss/tracking.vue
+++ b/src/components/sss/tracking.vue
@@ -40,7 +40,7 @@
                 <div class="columns">
                   <div class="row">
                     <div class="switch tiny">
-                      <input class="switch-input" id="resourceHistory" type="checkbox" v-model="toggleHistory" />
+                      <input class="switch-input" id="resourceHistory" type="checkbox" v-model="toggleHistory" @change="clearHistory" />
                       <label class="switch-paddle" for="resourceHistory">
                     <span class="show-for-sr">Query history</span>
                   </label>
@@ -194,6 +194,13 @@
       },
       downloadList: function () {
         this.$root.export.exportVector(this.features.filter(this.resourceFilter).sort(this.resourceOrder), 'trackingdata')
+      },
+      clearHistory: function () {
+          if (!this.toggleHistory) {
+              var historyLayer = this.$root.catalogue.getLayer('dpaw:resource_tracking_history')
+              historyLayer.cql_filter = "clearhistorylayer"
+              this.$root.catalogue.onLayerChange(historyLayer, false)
+          }
       },
       updateCQLFilter: function () {
         var vm = this


### PR DESCRIPTION
On hiding Query history form, clear the history search and remove the layer from view

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/parksandwildlife/gokart/9)
<!-- Reviewable:end -->
